### PR TITLE
Add posibility to exclude bad expert predictions from training set

### DIFF
--- a/bao/config.py
+++ b/bao/config.py
@@ -8,4 +8,8 @@ class SystemConfig():
     model_dir = osp.join(root_dir, "models")
     data_dir = osp.join(root_dir, "data")
 
+class ClassConfig(object):
+    bad_id_masks = ['00007882_001_2', '00000211_041_2', '00011355_011_2']
+
 system_config = SystemConfig()
+class_config = ClassConfig()

--- a/bao/utils.py
+++ b/bao/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os.path as osp
 
-from bao.config import system_config
+from bao.config import system_config, class_config
 
 
 def split_df(df, train_names_file=osp.join(system_config.data_dir, "processed", "train_names.txt"), colname="fname"):
@@ -10,3 +10,6 @@ def split_df(df, train_names_file=osp.join(system_config.data_dir, "processed", 
     df_train = df[np.isin(df["fname"], train_names)]
     df_val = df[~np.isin(df["fname"], train_names)]
     return df_train, df_val
+
+def filter_bad_mask_pred(df):
+    return df[~df['id'].isin(class_config.bad_id_masks)]


### PR DESCRIPTION
Теперь можно использовать эту функцию filter_bad_mask_pred(), чтобы удалить из выборки маски, в которых разметка эксперта не совпадает со скором, который выставил эксперт